### PR TITLE
Feature/yasar country entity cin 54

### DIFF
--- a/src/main/java/com/cinetime/entity/business/Country.java
+++ b/src/main/java/com/cinetime/entity/business/Country.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class Country {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/src/main/java/com/cinetime/entity/business/Country.java
+++ b/src/main/java/com/cinetime/entity/business/Country.java
@@ -1,0 +1,27 @@
+package com.cinetime.entity.business;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Country {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // TODO: 30 karakter sınırlaması bu şekilde yalnız DB'de mi yapılmalı
+  //  yoksa RequestDTO'sunda @Size ile de mi yapılmalı
+  @Column(nullable = false, length = 30)
+  private String name;
+}


### PR DESCRIPTION
Country entity'si oluşturuldu.

Proje yönergesinde name property'sinin max. 30 karakter olması gerektiği yazıyor. 

Buna göre  DB'e kaydedilirken gerçekleştirilecek bir validasyon ekledim. Ancak Samet Hoca ile yaptığımız projede yalnız NotNull kontrolünü hem DB'de hem RequestDTO'da yapmışız. Buradaki gibi karakter uzunluğu kontrollerini hep DTO'larda yapmışız. 

Her iki yerde de kontrol yapmanın zararı olmaz diye düşünüyorum. Bu hususta ilgili koda bir TODO ekledim. Onayınıza göre TODO'yu ve/veya DB validasyonu olan  @Column(lenght=30) kısmını silebilirim.