### PR TITLE
feature/ necessary class for testing JWT over Swagger.

### DIFF
--- a/src/main/java/com/cinetime/config/OpenAPIConfig.java
+++ b/src/main/java/com/cinetime/config/OpenAPIConfig.java
@@ -1,0 +1,23 @@
+package com.cinetime.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "CineTime API", version = "1.0.0"),
+    security = @SecurityRequirement(name = "BearerAuth")
+)
+@SecurityScheme(
+    name = "BearerAuth",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT"
+)
+public class OpenAPIConfig {
+
+}


### PR DESCRIPTION
What’s the benefit of this?

When Swagger UI opens, an Authorize button appears in the top-right corner 🔑

You enter the token there once, and it will be automatically included in all secured endpoints.

Otherwise, you would need to manually add the Authorization: Bearer <token> header for every single request.