### PR TITLE
Cine time/mustafa02

### DIFF
--- a/src/main/java/com/cinetime/security/config/SecurityConfig.java
+++ b/src/main/java/com/cinetime/security/config/SecurityConfig.java
@@ -21,6 +21,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.security.config.Customizer;
+import org.springframework.http.HttpMethod;
 
 @EnableWebSecurity
 @Configuration
@@ -36,11 +38,13 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
                 .exceptionHandling(ex ->
                         ex.authenticationEntryPoint(authEntryPointJwt)
                 )
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(AUTH_WHITELIST).permitAll()
                         .anyRequest().authenticated()
                 );


### PR DESCRIPTION
FrontEnd den bearer token gerektiren API call lar da header da token gondermeye izin vermeden 401 hatasi veriyordu, onu gidermek icin SecurityConfig de CORS a izin vermek lazimmis. ChatGPT ile onu ekledim. Simdi API call yapilabiliyor token gondererek.

Su an FrontEnd de login olmadigi icin tokeni hardcode ile FE e koyarak test ettim. Ama bu sekilde bilet satin alma islemlerini yapabiliyoruz. 